### PR TITLE
chore: adapt version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This action provides a sugar syntax to install the kubebuilder in the ubuntu mac
 ## Example usage
 
 ```yaml
-uses: RyanSiu1995/kubebuilder-action@v1
+uses: RyanSiu1995/kubebuilder-action@v1.1
 with:
   version: 2.3.1
 ```


### PR DESCRIPTION
One needs to use version 1.1 in order to avoid: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/