### PR TITLE
Update to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     description: 'Use sudo in the workflow'
     default: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Node 16 is deprecated, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
